### PR TITLE
Add failing tests for supporting LambdaConsumerIntrospection

### DIFF
--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -179,6 +179,14 @@ class FlowableTest {
     }
 
     @Test
+    @Ignore("Fix with adding support for LambdaConsumerIntrospection - #151")
+    fun testSubscribeByErrorIntrospectionDefaultWithOnComplete() {
+        val disposable = Flowable.just(Unit)
+                .subscribeBy(onComplete = {}) as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
     fun testBlockingSubscribeBy() {
         val first = AtomicReference<String>()
 

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -202,6 +202,14 @@ class ObservableTest {
     }
 
     @Test
+    @Ignore("Fix with adding support for LambdaConsumerIntrospection - #151")
+    fun testSubscribeByErrorIntrospectionDefaultWithOnComplete() {
+        val disposable = Observable.just(Unit)
+                .subscribeBy(onComplete = {}) as LambdaConsumerIntrospection
+        assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
     fun testBlockingSubscribeBy() {
         val first = AtomicReference<String>()
 


### PR DESCRIPTION
Hi,
I found a case where your solution for supporting LambdaConsumerIntrospection is not working.
Unfortunately I have no idea how to fix that yet.