### PR TITLE
Support LambdaConsumerIntrospection in subscribeBy.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'kotlin'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.1.0'
+    compile 'io.reactivex.rxjava2:rxjava:2.1.6'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile 'org.funktionale:funktionale-partials:1.0.0-final'
     testCompile 'junit:junit:4.12'

--- a/src/main/kotlin/io/reactivex/internal/functions/DefaultFunctions.kt
+++ b/src/main/kotlin/io/reactivex/internal/functions/DefaultFunctions.kt
@@ -1,0 +1,28 @@
+package io.reactivex.internal.functions
+
+import io.reactivex.functions.Action
+import io.reactivex.functions.Consumer
+
+fun <P1> ((P1) -> Unit)?.orDefaultConsumer(): Consumer<P1> {
+    return if (this == null) {
+        Functions.emptyConsumer<P1>()
+    } else {
+        Consumer(this)
+    }
+}
+
+fun ((Throwable) -> Unit)?.orDefaultOnError(): Consumer<Throwable> {
+    return if (this == null) {
+        Functions.ON_ERROR_MISSING
+    } else {
+        Consumer(this)
+    }
+}
+
+fun (() -> Unit)?.orDefaultOnComplete(): Action {
+    return if (this == null) {
+        Functions.EMPTY_ACTION
+    } else {
+        Action(this)
+    }
+}

--- a/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
+++ b/src/main/kotlin/io/reactivex/rxkotlin/subscribers.kt
@@ -2,70 +2,73 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.*
 import io.reactivex.disposables.Disposable
-import io.reactivex.exceptions.OnErrorNotImplementedException
-import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.functions.Consumer
+import io.reactivex.internal.functions.*
 
-private val onNextStub: (Any) -> Unit = {}
-private val onErrorStub: (Throwable) -> Unit = { RxJavaPlugins.onError(OnErrorNotImplementedException(it)) }
-private val onCompleteStub: () -> Unit = {}
+private typealias OnT<T> = ((T) -> Unit)?
+private typealias OnError = ((Throwable) -> Unit)?
+private typealias OnComplete = (() -> Unit)?
+/**
+ * Overloaded subscribe function that allows passing named parameters
+ */
+inline fun <reified T : Any> Observable<T>.subscribeBy(
+        noinline onError: OnError = null,
+        noinline onComplete: OnComplete = null,
+        noinline onNext: OnT<T> = null
+): Disposable = subscribe(onNext.orDefaultConsumer(), onError.orDefaultOnError(), onComplete.orDefaultOnComplete())
 
 /**
  * Overloaded subscribe function that allows passing named parameters
  */
-fun <T : Any> Observable<T>.subscribeBy(
-        onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub,
-        onNext: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onNext, onError, onComplete)
+inline fun <reified T : Any> Flowable<T>.subscribeBy(
+        noinline onError: OnError = null,
+        noinline onComplete: OnComplete = null,
+        noinline onNext: OnT<T> = null
+): Disposable = subscribe(onNext.orDefaultConsumer(), onError.orDefaultOnError(), onComplete.orDefaultOnComplete())
 
 /**
  * Overloaded subscribe function that allows passing named parameters
  */
-fun <T : Any> Flowable<T>.subscribeBy(
-        onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub,
-        onNext: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onNext, onError, onComplete)
+inline fun <reified T : Any> Single<T>.subscribeBy(
+        noinline onError: OnError = null,
+        noinline onSuccess: OnT<T> = null
+): Disposable = subscribe(onSuccess.orDefaultConsumer(), onError.orDefaultOnError())
 
 /**
  * Overloaded subscribe function that allows passing named parameters
  */
-fun <T : Any> Single<T>.subscribeBy(
-        onError: (Throwable) -> Unit = onErrorStub,
-        onSuccess: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onSuccess, onError)
-
-/**
- * Overloaded subscribe function that allows passing named parameters
- */
-fun <T : Any> Maybe<T>.subscribeBy(
-        onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub,
-        onSuccess: (T) -> Unit = onNextStub
-        ): Disposable = subscribe(onSuccess, onError, onComplete)
+inline fun <reified T : Any> Maybe<T>.subscribeBy(
+        noinline onError: OnError = null,
+        noinline onComplete: OnComplete = null,
+        noinline onSuccess: OnT<T> = null
+): Disposable = subscribe(onSuccess.orDefaultConsumer(), onError.orDefaultOnError(), onComplete.orDefaultOnComplete())
 
 /**
  * Overloaded subscribe function that allows passing named parameters
  */
 fun Completable.subscribeBy(
-        onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub
-): Disposable = subscribe(onComplete, onError)
+        onError: OnError = null,
+        onComplete: OnComplete = null
+): Disposable = if (onError == null) {
+    subscribe(onComplete.orDefaultOnComplete())
+} else {
+    subscribe(onComplete.orDefaultOnComplete(), Consumer(onError))
+}
 
 /**
  * Overloaded blockingSubscribe function that allows passing named parameters
  */
-fun <T : Any> Observable<T>.blockingSubscribeBy(
-        onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub,
-        onNext: (T) -> Unit = onNextStub
-        ) = blockingSubscribe(onNext, onError, onComplete)
+inline fun <reified T : Any> Observable<T>.blockingSubscribeBy(
+        noinline onError: OnError = null,
+        noinline onComplete: OnComplete = null,
+        noinline onNext: OnT<T> = null
+): Disposable = subscribe(onNext.orDefaultConsumer(), onError.orDefaultOnError(), onComplete.orDefaultOnComplete())
 
 /**
  * Overloaded blockingSubscribe function that allows passing named parameters
  */
-fun <T : Any> Flowable<T>.blockingSubscribeBy(
-        onError: (Throwable) -> Unit = onErrorStub,
-        onComplete: () -> Unit = onCompleteStub,
-        onNext: (T) -> Unit = onNextStub
-        ) = blockingSubscribe(onNext, onError, onComplete)
+inline fun <reified T : Any> Flowable<T>.blockingSubscribeBy(
+        noinline onError: OnError = null,
+        noinline onComplete: OnComplete = null,
+        noinline onNext: OnT<T> = null
+): Disposable = subscribe(onNext.orDefaultConsumer(), onError.orDefaultOnError(), onComplete.orDefaultOnComplete())

--- a/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/CompletableTest.kt
@@ -3,14 +3,16 @@ package io.reactivex.rxkotlin
 import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.functions.Action
+import io.reactivex.observers.LambdaConsumerIntrospection
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import org.mockito.Mockito
 import java.util.*
 import java.util.concurrent.Callable
 
-class CompletableTest {
+class CompletableTest : KotlinTests() {
 
     @Test fun testCreateFromAction() {
         var count = 0
@@ -52,4 +54,27 @@ class CompletableTest {
                 }
     }
 
+    @Test
+    fun testSubscribeBy() {
+        Completable.complete()
+                .subscribeBy {
+                    a.received(Unit)
+                }
+        Mockito.verify(a, Mockito.times(1))
+                .received(Unit)
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Completable.complete()
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Completable.complete()
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
+    }
 }

--- a/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/FlowableTest.kt
@@ -4,6 +4,7 @@ import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Flowable.create
 import io.reactivex.FlowableEmitter
+import io.reactivex.observers.LambdaConsumerIntrospection
 import io.reactivex.subscribers.TestSubscriber
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -161,6 +162,27 @@ class FlowableTest {
                     first.set(it)
                 }
         Assert.assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Flowable.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Flowable.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionDefaultWithOnComplete() {
+        val disposable = Flowable.just(Unit)
+                .subscribeBy(onComplete = {}) as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
     }
 
     @Test

--- a/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/MaybeTest.kt
@@ -1,6 +1,8 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Maybe
+import io.reactivex.Single
+import io.reactivex.observers.LambdaConsumerIntrospection
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicReference
@@ -15,6 +17,20 @@ class MaybeTest {
                     first.set(it)
                 }
         Assert.assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Single.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Single.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
     }
 
     @Test fun testConcatAll() {

--- a/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/ObservableTest.kt
@@ -1,6 +1,7 @@
 package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
+import io.reactivex.observers.LambdaConsumerIntrospection
 import io.reactivex.observers.TestObserver
 import org.junit.Assert
 import org.junit.Assert.*
@@ -184,6 +185,27 @@ class ObservableTest {
                     first.set(it)
                 }
         assertTrue(first.get() == "Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Observable.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Observable.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        assertTrue(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionDefaultWithOnComplete() {
+        val disposable = Observable.just(Unit)
+                .subscribeBy(onComplete = {}) as LambdaConsumerIntrospection
+        assertFalse(disposable.hasCustomOnError())
     }
 
     @Test

--- a/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
+++ b/src/test/kotlin/io/reactivex/rxkotlin/SingleTest.kt
@@ -2,6 +2,7 @@ package io.reactivex.rxkotlin
 
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.reactivex.observers.LambdaConsumerIntrospection
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
@@ -56,6 +57,20 @@ class SingleTest : KotlinTests() {
                 }
         verify(a, Mockito.times(1))
                 .received("Alpha")
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospection() {
+        val disposable = Single.just(Unit)
+                .subscribeBy() as LambdaConsumerIntrospection
+        Assert.assertFalse(disposable.hasCustomOnError())
+    }
+
+    @Test
+    fun testSubscribeByErrorIntrospectionCustom() {
+        val disposable = Single.just(Unit)
+                .subscribeBy(onError = {}) as LambdaConsumerIntrospection
+        Assert.assertTrue(disposable.hasCustomOnError())
     }
 
     @Test fun testConcatAll() {


### PR DESCRIPTION
Hey,
I have fixed those two missing cases.
What do you think about such solution?
Can we propose such change instead of https://github.com/ReactiveX/RxKotlin/pull/151?
